### PR TITLE
Add ReplaceFileAtIndex to HelperFunctions

### DIFF
--- a/SA2ModLoader/FileMap.cpp
+++ b/SA2ModLoader/FileMap.cpp
@@ -70,8 +70,9 @@ void FileMap::addIgnoreFile(const string& ignoreFile, int modIdx)
  * Add a file replacement.
  * @param origFile Original filename.
  * @param modFile Mod filename.
+ * @param modIndex Optional mod index.
  */
-void FileMap::addReplaceFile(const std::string& origFile, const std::string& modFile)
+void FileMap::addReplaceFile(const std::string& origFile, const std::string& modFile, const int modIndex)
 {
 	string origFile_norm = normalizePath(origFile);
 	string modFile_norm = normalizePath(modFile);
@@ -87,7 +88,7 @@ void FileMap::addReplaceFile(const std::string& origFile, const std::string& mod
 	else
 	{
 		// Destination file is not already in the map.
-		setReplaceFile(origFile_norm, modFile_norm, INT_MAX);
+		setReplaceFile(origFile_norm, modFile_norm, modIndex);
 	}
 }
 

--- a/SA2ModLoader/FileMap.hpp
+++ b/SA2ModLoader/FileMap.hpp
@@ -44,8 +44,9 @@ public:
 	 * Add a file replacement.
 	 * @param origFile Original filename.
 	 * @param modFile Mod filename.
+	 * @param modIndex Optional mod index.
 	 */
-	void addReplaceFile(const std::string& origFile, const std::string& modFile);
+	void addReplaceFile(const std::string& origFile, const std::string& modFile, const int modIndex = INT_MAX);
 
 	/**
 	 * Remove a file replacement.

--- a/SA2ModLoader/HelperFunctions.cpp
+++ b/SA2ModLoader/HelperFunctions.cpp
@@ -243,14 +243,25 @@ void ReplaceFileAtIndex(const char* src, const char* dst, int modIndex)
 {
 	string orig = sadx_fileMap.normalizePath(src);
 	string mod = sadx_fileMap.normalizePath(dst);
-	sadx_fileMap.addReplaceFile(orig, mod, modIndex);
+
+	if (sadx_fileMap.getModIndex(orig.c_str()) <= modIndex) {
+		sadx_fileMap.addReplaceFile(orig, mod, modIndex);
+	}
+
 	auto i = orig.find("\\prs\\");
 	if (i != string::npos)
 	{
 		orig.erase(i, 4);
 		ReplaceFileExtension(orig, ".prs");
-		sadx_fileMap.addReplaceFile(orig, mod, modIndex);
+		if (sadx_fileMap.getModIndex(orig.c_str()) <= modIndex) {
+			sadx_fileMap.addReplaceFile(orig, mod, modIndex);
+		}
 	}
+}
+
+int GetFileModIndex(const char* path) {
+	string normalizedPath = sadx_fileMap.normalizePath(path);
+	return sadx_fileMap.getModIndex(normalizedPath.c_str());
 }
 
 void SetWindowTitle(const wchar_t* title)
@@ -393,5 +404,6 @@ HelperFunctions helperFunctions = {
 	&UnreplaceFile,
 	&PushInterpolationFix,
 	&PopInterpolationFix,
+	&GetFileModIndex,
 	&ReplaceFileAtIndex
 };

--- a/SA2ModLoader/HelperFunctions.cpp
+++ b/SA2ModLoader/HelperFunctions.cpp
@@ -225,20 +225,6 @@ const char* __cdecl GetReplaceablePath(const char* path)
 	return sadx_fileMap.replaceFile(path);
 }
 
-void _ReplaceFile(const char* src, const char* dst)
-{
-	string orig = sadx_fileMap.normalizePath(src);
-	string mod = sadx_fileMap.normalizePath(dst);
-	sadx_fileMap.addReplaceFile(orig, mod);
-	auto i = orig.find("\\prs\\");
-	if (i != string::npos)
-	{
-		orig.erase(i, 4);
-		ReplaceFileExtension(orig, ".prs");
-		sadx_fileMap.addReplaceFile(orig, mod);
-	}
-}
-
 void ReplaceFileAtIndex(const char* src, const char* dst, int modIndex)
 {
 	string orig = sadx_fileMap.normalizePath(src);
@@ -257,6 +243,11 @@ void ReplaceFileAtIndex(const char* src, const char* dst, int modIndex)
 			sadx_fileMap.addReplaceFile(orig, mod, modIndex);
 		}
 	}
+}
+
+void _ReplaceFile(const char* src, const char* dst)
+{
+	ReplaceFileAtIndex(src, dst, INT_MAX);
 }
 
 int GetFileModIndex(const char* path) {

--- a/SA2ModLoader/HelperFunctions.cpp
+++ b/SA2ModLoader/HelperFunctions.cpp
@@ -239,6 +239,20 @@ void _ReplaceFile(const char* src, const char* dst)
 	}
 }
 
+void ReplaceFileAtIndex(const char* src, const char* dst, int modIndex)
+{
+	string orig = sadx_fileMap.normalizePath(src);
+	string mod = sadx_fileMap.normalizePath(dst);
+	sadx_fileMap.addReplaceFile(orig, mod, modIndex);
+	auto i = orig.find("\\prs\\");
+	if (i != string::npos)
+	{
+		orig.erase(i, 4);
+		ReplaceFileExtension(orig, ".prs");
+		sadx_fileMap.addReplaceFile(orig, mod, modIndex);
+	}
+}
+
 void SetWindowTitle(const wchar_t* title)
 {
 	if (MainWindowHandle)
@@ -379,4 +393,5 @@ HelperFunctions helperFunctions = {
 	&UnreplaceFile,
 	&PushInterpolationFix,
 	&PopInterpolationFix,
+	&ReplaceFileAtIndex
 };

--- a/SA2ModLoader/include/SA2ModInfo.h
+++ b/SA2ModLoader/include/SA2ModInfo.h
@@ -286,6 +286,11 @@ struct HelperFunctions
 	// Requires version >= 13.
 	void(__cdecl* PopInterpolationFix)();
 
+	// Retrieves the index of the mod that replaced the file specified in the path.
+	// Returns 0 if the file wasn't replaced by a mod.
+	// Requires version >= 16.
+	int(__cdecl* GetFileModIndex)(const char* path);
+
 	// Replaces the source file with the destination file, with the specified mod index being used to determine the order of replacement.
 	// Requires version >= 16.
 	void(__cdecl* ReplaceFileAtIndex)(const char* src, const char* dst, int modIndex);

--- a/SA2ModLoader/include/SA2ModInfo.h
+++ b/SA2ModLoader/include/SA2ModInfo.h
@@ -8,7 +8,7 @@
 
 #include "SA2Structs.h"
 
-static const int ModLoaderVer = 15;
+static const int ModLoaderVer = 16;
 
 struct PatchInfo
 {
@@ -285,6 +285,10 @@ struct HelperFunctions
 	// Disable interpolation fix for animations, use it at the end of a display function.
 	// Requires version >= 13.
 	void(__cdecl* PopInterpolationFix)();
+
+	// Replaces the source file with the destination file, with the specified mod index being used to determine the order of replacement.
+	// Requires version >= 16.
+	void(__cdecl* ReplaceFileAtIndex)(const char* src, const char* dst, int modIndex);
 };
 
 typedef void(__cdecl* ModInitFunc)(const char* path, const HelperFunctions& helperFunctions);


### PR DESCRIPTION
Added ReplaceFileAtIndex to HelperFunctions, does the exact same thing as ReplaceFile but with a modIndex parameter. In FileMap, I added an optional modIndex parameter to "addReplaceFile" which defaults to INT_MAX as before. ReplaceFileAtIndex passes the modIndex parameter to this optional parameter. I also incremented ModLoaderVer to 16, and specified that you need that version minimum in the helperfunctions description to use this.