### PR TITLE
Change the file map index logic to use `-1` to represent "no mod", rather than `0`

### DIFF
--- a/SA2ModLoader/FileMap.cpp
+++ b/SA2ModLoader/FileMap.cpp
@@ -460,7 +460,7 @@ const char* FileMap::replaceFile(const char* lpFileName) const
 /**
  * Get a filename from the file replacement map.
  * @param[in] lpFileName Filename.
- * @param[out] modIndex Index of the mod that replaced a file, or 0 if no mod replaced it.
+ * @param[out] modIndex Index of the mod that replaced a file, or -1 if no mod replaced it.
  * @return Replaced filename, or original filename if not replaced by a mod.
  */
 const char* FileMap::replaceFile(const char* lpFileName, int& modIndex) const
@@ -479,14 +479,14 @@ const char* FileMap::replaceFile(const char* lpFileName, int& modIndex) const
 
 	// File was not replaced by a mod.
 	// Return the filename as-is.
-	modIndex = 0;
+	modIndex = -1;
 	return lpFileName;
 }
 
 /**
  * Get the index of the mod that replaced a given file.
  * @param lpFileName Filename.
- * @return Index of the mod that replaced a file, or 0 if no mod replaced it.
+ * @return Index of the mod that replaced a file, or -1 if no mod replaced it.
  */
 int FileMap::getModIndex(const char* lpFileName) const
 {
@@ -499,7 +499,7 @@ int FileMap::getModIndex(const char* lpFileName) const
 	}
 
 	// File was not replaced by a mod.
-	return 0;
+	return -1;
 }
 
 /**

--- a/SA2ModLoader/config.cpp
+++ b/SA2ModLoader/config.cpp
@@ -16,7 +16,7 @@ vector<std::string> GamePatchList;
 
 std::string GetModName(int index)
 {
-	return ModList.at(index - 1);
+	return ModList.at(index);
 }
 
 int GetModCount()

--- a/SA2ModLoader/dllmain.cpp
+++ b/SA2ModLoader/dllmain.cpp
@@ -1196,7 +1196,7 @@ void __cdecl InitMods(void)
 		const string mod_nameA = modinfo->getString("Name");
 		const wstring mod_name = modinfo->getWString("Name");
 
-		PrintDebug("%u. %s\n", i, mod_nameA.c_str());
+		PrintDebug("%u. %s\n", i + 1, mod_nameA.c_str());
 
 		vector<ModDependency> moddeps;
 

--- a/SA2ModLoader/dllmain.cpp
+++ b/SA2ModLoader/dllmain.cpp
@@ -1168,7 +1168,7 @@ void __cdecl InitMods(void)
 	// It's mod loading time!
 	PrintDebug("Loading mods...\n");
 	// Mod list
-	for (unsigned int i = 0; i <= GetModCount(); i++)
+	for (unsigned int i = 0; i < GetModCount(); i++)
 	{
 		std::string mod_fname = GetModName(i);
 

--- a/SA2ModLoader/dllmain.cpp
+++ b/SA2ModLoader/dllmain.cpp
@@ -1168,7 +1168,7 @@ void __cdecl InitMods(void)
 	// It's mod loading time!
 	PrintDebug("Loading mods...\n");
 	// Mod list
-	for (unsigned int i = 1; i <= GetModCount(); i++)
+	for (unsigned int i = 0; i <= GetModCount(); i++)
 	{
 		std::string mod_fname = GetModName(i);
 


### PR DESCRIPTION
By doing this, we synchronize the logic across the codebase and accross the user accessible `HelperFunctions` when `getModIndex` function is finally exposed.

If this is not done, the `ModInfo` mod indeces will start at 0, but the `getModIndex` indeces will start at 1 - this means users will have needed to convert between the functions.